### PR TITLE
Fix adapter for iOS5

### DIFF
--- a/highcharts-zepto.src.js
+++ b/highcharts-zepto.src.js
@@ -175,7 +175,7 @@ win.HighchartsAdapter = {
    */
   addEvent: function (el, event, fn) {
     // console.log("add "+event+" "+(typeof el)+" "+el.nodeType+" "+el.tagName);
-    if (typeof el.nodeType == "undefined" && !(el instanceof Window)) {
+    if (typeof el.nodeType == "undefined" && !(el instanceof window.constructor)) {
       Events.eventify(el);
       el.bind(event, fn);
     } else


### PR DESCRIPTION
In iOS5 I got the strange javascript error: 
`Reference Error: Can't find variable: Window`
Apparently in iOS5 `window` has the constructor called `DOMWindowConstructor`.

Comparing `instanceof window.constructor` instead of `Window`solved the problem.
